### PR TITLE
Use the generic ListExporter and refactor code for 2.4+

### DIFF
--- a/pretix_checkinlist_net/exporters.py
+++ b/pretix_checkinlist_net/exporters.py
@@ -184,8 +184,8 @@ class CheckInListMixin(BaseExporter):
 
 class CSVCheckinListNet(CheckInListMixin, ListExporter):
     name = "overview"
-    identifier = 'checkinlistcsvnet'
-    verbose_name = ugettext_lazy('Check-in list (CSV) for NETWAYS')
+    identifier = 'checkinlistnet'
+    verbose_name = ugettext_lazy('Check-in list for NETWAYS')
 
     @property
     def additional_form_fields(self):


### PR DESCRIPTION
- Generic Mixin like upstream exporters
- _get_queryset and _get_dataset helper abstractions
- Our class inherits from ListExporter and just implements the list
iterator and resulting file name
- Generated file name now includes the event slug
- ListExporter supports Excel xlsx and more CSV separator options, dropped
custom CSV writer
- Support for attendee name parts, if chosen in event settings